### PR TITLE
Fix `ifProgress` example

### DIFF
--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -1205,7 +1205,7 @@ JS whitespace, you could say:
       succeed identity
         |. parser
         |= getOffset
-        |> andThen (\newOffset -> if offset == newOffset then Done () else Loop newOffset)
+        |> map (\newOffset -> if offset == newOffset then Done () else Loop newOffset)
 
 **Note:** The fact that `spaces` comes last in the definition of `elm` is very
 important! It can succeed without consuming any characters, so if it were the


### PR DESCRIPTION
The `ifProgress` [example](https://alpha.elm-lang.org/packages/elm/parser/latest/Parser#multiComment) does not compile:
```elm
The 1st argument to `andThen` is not what I expect:

33|     |> andThen (\newOffset -> if offset == newOffset then Done () else Loop newOffset)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
This argument is an anonymous function of type:

    Int -> Step Int ()

But `andThen` needs the 1st argument to be:

    Int -> Parser b
```

`andThen` should be `map`.