### PR TITLE
Add dead end clarification to chompIf doc

### DIFF
--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -801,7 +801,7 @@ mapChompedString =
 
 
 
-{-| Chomp one character if it passes the test.
+{-| Chomp one character if it passes the test. Dead end if it does not pass the test.
 
     chompUpper : Parser ()
     chompUpper =


### PR DESCRIPTION
Just a suggestion here. I think because of how "if" and "while" usually work in programming languages, I assumed `chompIf` was like a "parse one or move on" rather than a "parse one or dead end"-type thing, and spent a bit trying to figure out how to do a `chompOne` function before realizing my mistake. I figure this might prevent others from possibly making the same error.

For me, at least, I think `chompOne` might be a clearer name, even though I can totally see how `chompIf` makes sense.