### PR TITLE
Fix bug in chompUntil and chompUntilEndOr

### DIFF
--- a/src/Parser/Advanced.elm
+++ b/src/Parser/Advanced.elm
@@ -893,9 +893,9 @@ chompUntil (Token str expecting) =
       Bad False (fromInfo newRow newCol expecting s.context)
 
     else
-      Good (s.offset < newOffset) ()
+      Good (s.offset < newOffset + String.length str) ()
         { src = s.src
-        , offset = newOffset
+        , offset = newOffset + String.length str
         , indent = s.indent
         , context = s.context
         , row = newRow
@@ -913,7 +913,7 @@ chompUntilEndOr str =
         Elm.Kernel.Parser.findSubString str s.offset s.row s.col s.src
 
       adjustedOffset =
-        if newOffset < 0 then String.length s.src else newOffset
+        if newOffset < 0 then String.length s.src else newOffset + String.length str
     in
     Good (s.offset < adjustedOffset) ()
       { src = s.src


### PR DESCRIPTION
This fixes #20 (and also #2 ).

I tested with the table in @ianmackenzie 's nice report.
Seems like working correctly.

![image](https://user-images.githubusercontent.com/2568148/47936906-88b14080-df22-11e8-9458-e981b35069e3.png)