### PR TITLE
Fix comment in `findSubString`

### DIFF
--- a/src/Parser/Advanced.elm
+++ b/src/Parser/Advanced.elm
@@ -1125,7 +1125,7 @@ isAsciiCode =
     findSubString "42" offset row col "Is 42 the answer?"
         --==> (newOffset, newRow, newCol)
 
-If `offset = 0` we would get `(3, 1, 4)`
+If `offset = 0` we would get `(3, 1, 6)`
 If `offset = 7` we would get `(-1, 1, 18)`
 -}
 findSubString : String -> Int -> Int -> Int -> String -> (Int, Int, Int)


### PR DESCRIPTION
This comment isn't in line with what the code actually does, and given code can't lie but comments can, the place to fix is probably the comment.

See [findSubString](https://github.com/elm/parser/blob/master/src/Elm/Kernel/Parser.js#L123) - the `newOffset + smallString.length` means the target is pointed at the end of the found substring, not at its beginning.
```elm
--    v = newOffset
  "Is 42 the answer?"
--      ^ = newOffset + smallString.length
-- 1234567...
```