### PR TITLE
Update examples/elm.json to be ready for Elm 0.19.1

### DIFF
--- a/examples/elm.json
+++ b/examples/elm.json
@@ -1,21 +1,21 @@
 {
     "type": "application",
     "source-directories": [
-        "."
+        "src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.4",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0"
         },
         "indirect": {
-            "elm/json": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
Before it was setup to be ready for Elm 0.19.0 which means
you see an error when trying to run the exmaple in Elm 0.19.1.

Now that Elm 0.19.1 is released it seems, to me at least, to be
a good idea for the examples to run by default on that version,
and for the user to have to modify it to run a different version.