### PR TITLE
Fix dead link in Parser.Advanced

### DIFF
--- a/src/Parser/Advanced.elm
+++ b/src/Parser/Advanced.elm
@@ -1328,7 +1328,7 @@ multiComment open close nestable =
       nestableComment open close
 
 
-{-| Works just like [`Parser.Nestable`](Parser#nestable) to help distinguish
+{-| Works just like [`Parser.Nestable`](Parser#Nestable) to help distinguish
 between unnestable `/*` `*/` comments like in JS and nestable `{-` `-}`
 comments like in Elm.
 -}


### PR DESCRIPTION
Hi :wave: 

I noticed that a link in this file was not leading to the expected location.

PS: I noticed this through an `elm-review` rule to be published soon :)